### PR TITLE
feat: Set up custom CSS override for Jekyll theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Exclude any backup files
 *~
+_site/

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,9 @@
+// Import the original theme styles (based on build log analysis)
+@import "vendor/tailwind";
+@import "garden";
+@import "search";
+
+// Custom CSS rules
+body {
+  background-color: #FF00FF !important; // A very obvious color for testing
+}


### PR DESCRIPTION
This commit establishes the foundation for custom theming.

Here's what I did:
1. I looked at the existing `_config.yml` to identify the remote theme (`zendesk/jekyll-theme-zendesk-garden`).
2. I researched methods to add custom CSS to this specific theme. My initial attempts to use a `custom_css_url` in `_config.yml` were unsuccessful as the theme doesn't appear to support this method directly.
3. I adopted a standard Jekyll theme override technique:
    - I created `assets/css/style.scss`.
    - This file imports the core Sass partials from the remote theme (`vendor/tailwind`, `garden`, `search`) to ensure base styles are maintained.
    - I added a temporary, highly visible CSS rule (`body { background-color: #FF00FF !important; }`) to `assets/css/style.scss` for testing purposes.
4. I confirmed via Jekyll build logs that `assets/css/style.scss` is being correctly processed and overrides the theme's default `style.scss`.
5. I removed the `custom_css_url` entry from `_config.yml` as it was not effective.

The site now successfully builds with this custom CSS injection point. The next steps would involve removing the test background color and populating `assets/css/style.scss` with actual styles to match the UCR ITS website.