### PR TITLE
Refactor: Move research records retention guide to Knowledge Base

### DIFF
--- a/Knowledge_Base/knowledge-base.md
+++ b/Knowledge_Base/knowledge-base.md
@@ -52,6 +52,7 @@ Welcome to the UCR Research Computing Knowledge Base. Explore our comprehensive 
 
 - [UCR RCSAS](UCR_Research_Computing_System_Administration_Service.md): Overview of the Research Computing System Administration Service.
 - [RCSAS MOU](https://docs.google.com/document/d/19nYYXakruAbg1pxKybpSddSz8p1TBiBc/edit?usp=sharing&ouid=115996119773834121624&rtpof=true&sd=true): Service agreement details for RCSAS.
+- [UC Riverside Research Records Retention A Quick Guide for Researchers](../pages/ucr_research_records_retention_guide.md)
 
 ### Software
 

--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,6 @@ sidebar:
       - infrastructure-support
       - grant-collaboration
       - lab-support
-      - ucr-research-records-retention-guide
   - label: Training
     children:
       - workshops-and-webinars


### PR DESCRIPTION
The research records retention guide page was previously linked directly from your main sidebar navigation under 'Support'.

This change:
- Removes the direct link from the sidebar in `_config.yml`.
- Adds a link to the guide on the main Knowledge Base page (`Knowledge_Base/knowledge-base.md`) under the 'Support' section.

This makes the guide accessible through the Knowledge Base, centralizing such resources.